### PR TITLE
Fixes Broken Links

### DIFF
--- a/app/views/tests/index.html.erb
+++ b/app/views/tests/index.html.erb
@@ -7,12 +7,12 @@
 
 <% if @discogs.authenticated? %>
   <ul>
-    <li><a href="/images/R-2795264-1301352416.jpeg">View image</a></li>
-    <li><a href="/images/whoami">User information</a></li>
-    <li><a href="/images/add_want">Add 'Medieval Steel' to wantlist</a></li>
-    <li><a href="/images/edit_want">Edit 'Medieval Steel' in wantlist</a></li>
-    <li><a href="/images/remove_want">Remove 'Medieval Steel' from wantlist</a></li>
+    <li><a href="/tests/R-2795264-1301352416.jpeg">View image</a></li>
+    <li><a href="/tests/whoami">User information</a></li>
+    <li><a href="/tests/add_want">Add 'Medieval Steel' to wantlist</a></li>
+    <li><a href="/tests/edit_want">Edit 'Medieval Steel' in wantlist</a></li>
+    <li><a href="/tests/remove_want">Remove 'Medieval Steel' from wantlist</a></li>
   </ul>
 <% else %>
-  <a href="/images/authenticate">Authenticate Discogs.com account</a>
+  <a href="/tests/authenticate">Authenticate Discogs.com account</a>
 <% end %>


### PR DESCRIPTION
When I spun this up earlier, I noticed that all the links in the `tests#index` view were pointing to a nonexistent `images` path.

Pointing them instead to `/tests` cleared up the 404 errors.
